### PR TITLE
Improve drawcustom editor layout

### DIFF
--- a/tools/editor/index.html
+++ b/tools/editor/index.html
@@ -7,15 +7,16 @@
 </head>
 <body>
   <h1>Drawcustom Editor</h1>
-  <div id="display-area">
-    <canvas id="canvas" width="296" height="128"></canvas>
-  </div>
-  <div id="service-options">
-    <h2>Renderer</h2>
-    <div id="renderer-toggle" class="renderer-toggle">
-      <label><input type="radio" name="renderer" id="renderer-js" value="js" checked> JavaScript</label>
-      <label><input type="radio" name="renderer" id="renderer-py" value="py"> Python (Pyodide)</label>
+  <div id="top-container">
+    <div id="display-area">
+      <canvas id="canvas" width="296" height="128"></canvas>
     </div>
+    <div id="service-options">
+      <h2>Renderer</h2>
+      <div id="renderer-toggle" class="renderer-toggle">
+        <label><input type="radio" name="renderer" id="renderer-js" value="js" checked> JavaScript</label>
+        <label><input type="radio" name="renderer" id="renderer-py" value="py"> Python (Pyodide)</label>
+      </div>
     <h2>Screen Size</h2>
     <select id="screen-size">
       <option value="296x128">296x128</option>
@@ -38,7 +39,8 @@
     <label>Rotate <input type="number" id="rotate" value="0" min="0" max="270" step="90"></label>
     <label>Dither <input type="number" id="dither" value="2" min="0" max="2"></label>
     <label>TTL <input type="number" id="ttl" value="60" min="0"></label>
-    <label>Dry-run <input type="checkbox" id="dry-run"></label>
+      <label>Dry-run <input type="checkbox" id="dry-run"></label>
+    </div>
   </div>
   <h2>Add Element</h2>
   <div id="element-buttons" class="element-buttons"></div>

--- a/tools/editor/script.js
+++ b/tools/editor/script.js
@@ -6,6 +6,7 @@ let backend = 'js';
 let screenWidth = canvas.width;
 let screenHeight = canvas.height;
 let selectedIndex = null;
+let elementRefs = [];
 let dragging = false;
 let dragStartX = 0;
 let dragStartY = 0;
@@ -642,17 +643,32 @@ function draw() {
   }
 }
 
+function selectElement(i) {
+  selectedIndex = i;
+  elementRefs.forEach((ref, idx) => {
+    if (!ref) return;
+    if (idx === i) ref.div.classList.add('selected');
+    else ref.div.classList.remove('selected');
+  });
+}
+
+function updateElementTextarea(i) {
+  const ref = elementRefs[i];
+  if (ref) {
+    ref.ta.value = jsyaml.dump(elements[i]);
+  }
+}
+
 function renderElementList() {
   const container = document.getElementById('elements');
+  const scroll = container.scrollTop;
   container.innerHTML = '';
+  elementRefs = [];
   elements.forEach((el, i) => {
     const div = document.createElement('div');
     div.className = 'element';
     if (i === selectedIndex) div.classList.add('selected');
-    div.onclick = () => {
-      selectedIndex = i;
-      renderElementList();
-    };
+    div.onclick = () => selectElement(i);
     const ta = document.createElement('textarea');
     ta.rows = 6;
     ta.value = jsyaml.dump(el);
@@ -678,7 +694,9 @@ function renderElementList() {
     div.appendChild(ta);
     div.appendChild(del);
     container.appendChild(div);
+    elementRefs[i] = { div, ta };
   });
+  container.scrollTop = scroll;
 }
 
 function createElementButtons() {
@@ -811,7 +829,7 @@ canvas.addEventListener('mousemove', (e) => {
   }
   dragStartX = x;
   dragStartY = y;
-  renderElementList();
+  updateElementTextarea(selectedIndex);
   draw();
 });
 
@@ -825,4 +843,5 @@ canvas.addEventListener('mouseleave', () => {
 createElementButtons();
 updateScreenSize();
 updateZoom();
+renderElementList();
 draw();

--- a/tools/editor/style.css
+++ b/tools/editor/style.css
@@ -4,6 +4,12 @@ body {
   padding: 0 10px;
 }
 
+#top-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+}
+
 #display-area {
   text-align: center;
   margin: 10px 0;
@@ -16,16 +22,18 @@ body {
 
 #service-options {
   position: sticky;
-  top: 0;
+  top: 10px;
   background: #fff;
   padding: 10px;
-  border-bottom: 1px solid #ccc;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  max-width: 250px;
   z-index: 1;
 }
 
 #service-options label {
-  display: inline-block;
-  margin: 5px 5px 0 0;
+  display: block;
+  margin: 3px 0;
 }
 
 .element-buttons {


### PR DESCRIPTION
## Summary
- tweak editor layout so service options sit next to the canvas
- keep element textarea scroll positions when selecting or dragging
- allow resizing the textarea without it snapping back

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685920aa1ad0832bb7f121943f9a9fbe