### PR TITLE
Fix decoding of uncompressed images

### DIFF
--- a/custom_components/open_epaper_link/image_decompressor.py
+++ b/custom_components/open_epaper_link/image_decompressor.py
@@ -92,6 +92,11 @@ def decode_esl_raw(data: bytes, tag_type: TagType) -> bytes:
                     data = decompressed_data[header_size:]
             else:
                 _LOGGER.debug("Data appears to be uncompressed")
+                # Strip header from uncompressed data
+                header_total = 4 + header_size
+                if len(data) >= header_total:
+                    data = data[header_total:]
+
                 # For uncompressed data, pad if necessary
                 if len(data) < total_size:
                     _LOGGER.debug(f"Padding uncompressed data to {total_size} bytes")
@@ -101,6 +106,12 @@ def decode_esl_raw(data: bytes, tag_type: TagType) -> bytes:
     except Exception as e:
         _LOGGER.debug(f"Processing failed: {e}")
         _LOGGER.debug("Treating as raw data")
+
+        # Strip header if present
+        header_total = 4 + header_size
+        if len(data) >= header_total:
+            data = data[header_total:]
+
         if len(data) < total_size:
             _LOGGER.debug(f"Padding raw data to {total_size} bytes")
             data = data.ljust(total_size, b'\x00')

--- a/tests/test_image_decompressor.py
+++ b/tests/test_image_decompressor.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+# Set up minimal package structure so relative imports resolve
+pkg = types.ModuleType("custom_components")
+sys.modules["custom_components"] = pkg
+open_pkg = types.ModuleType("custom_components.open_epaper_link")
+open_pkg.__path__ = []
+sys.modules["custom_components.open_epaper_link"] = open_pkg
+# Stub tag_types module required by image_decompressor
+stub_tag_types = types.ModuleType("custom_components.open_epaper_link.tag_types")
+stub_tag_types.TagType = object
+sys.modules["custom_components.open_epaper_link.tag_types"] = stub_tag_types
+
+spec = importlib.util.spec_from_file_location(
+    "custom_components.open_epaper_link.image_decompressor",
+    Path(__file__).resolve().parent.parent / "custom_components/open_epaper_link/image_decompressor.py",
+)
+image_decompressor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(image_decompressor)
+decode_esl_raw = image_decompressor.decode_esl_raw
+
+
+def test_decode_esl_raw_uncompressed_header_removed():
+    tag_type = SimpleNamespace(
+        name="test",
+        width=8,
+        height=8,
+        bpp=1,
+        rotatebuffer=0,
+        color_table={'white': [255, 255, 255], 'black': [0, 0, 0]},
+    )
+
+    plane = bytes([0xAA] * 8)
+    raw = (0).to_bytes(4, 'little') + b'\x00' * 6 + plane
+
+    result = decode_esl_raw(raw, tag_type)
+    assert result == plane
+    assert len(result) == len(plane)


### PR DESCRIPTION
## Summary
- remove leftover headers when decoding uncompressed raw images
- add regression test for uncompressed raw decoding

## Testing
- `pytest tests/test_image_decompressor.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil_home_assistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a4347d7ccc832b9d7a6e1c1358fd00