### PR TITLE
Centralize tag updates across hubs

### DIFF
--- a/custom_components/open_epaper_link/__init__.py
+++ b/custom_components/open_epaper_link/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.const import Platform, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .hub import Hub
+from .tag_registry import TagRegistry
 from .services import async_setup_services, async_unload_services
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -39,13 +40,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     Returns:
         bool: True if setup was successful, False otherwise
     """
-    hub = Hub(hass, entry)
-
+    component_data = hass.data.setdefault(DOMAIN, {})
+    tag_registry = component_data.setdefault("tag_registry", TagRegistry(hass))
+    hub = Hub(hass, entry, tag_registry)
     # Do basic setup without WebSocket connection
     if not await hub.async_setup_initial():
         return False
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
+    component_data[entry.entry_id] = hub
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/open_epaper_link/tag_registry.py
+++ b/custom_components/open_epaper_link/tag_registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import SIGNAL_TAG_UPDATE
+
+
+class TagRegistry:
+    """Global coordinator for OpenEPaperLink tag data."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the registry."""
+        self.hass = hass
+        self._data: Dict[str, dict] = {}
+
+    @property
+    def tags(self) -> list[str]:
+        """Return list of tracked tag MAC addresses."""
+        return list(self._data.keys())
+
+    def get_tag_data(self, tag_mac: str) -> dict:
+        """Return stored data for a tag."""
+        return self._data.get(tag_mac, {})
+
+    def update_tag(self, tag_mac: str, data: dict, source: str) -> None:
+        """Update registry with new tag data and notify listeners."""
+        data_copy = data.copy()
+        data_copy["last_ap_host"] = source
+        self._data[tag_mac] = data_copy
+        async_dispatcher_send(self.hass, f"{SIGNAL_TAG_UPDATE}_{tag_mac}")
+
+    def remove_tag(self, tag_mac: str) -> None:
+        """Remove a tag from the registry and notify listeners."""
+        self._data.pop(tag_mac, None)
+        async_dispatcher_send(self.hass, f"{SIGNAL_TAG_UPDATE}_{tag_mac}")


### PR DESCRIPTION
## Summary
- create TagRegistry to hold tag state from all hubs
- push tag updates and removals through registry and dispatch signals
- sensors read tag data from registry for cross-hub resiliency
- track last_ap_host per tag and expose a connection binary sensor per hub

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'psutil_home_assistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a6e34243fc832b97518f371a66d70e