### PR TITLE
Fix duplicate device entries for primary hub

### DIFF
--- a/custom_components/open_epaper_link/binary_sensor.py
+++ b/custom_components/open_epaper_link/binary_sensor.py
@@ -7,11 +7,12 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SIGNAL_EXTERNAL_HUB_DISCOVERED
 from .hub import Hub
+from .util import get_ap_device_info
 
 import logging
 
@@ -30,12 +31,7 @@ class OpenEPaperLinkWSBinarySensor(BinarySensorEntity):
         self._hub = hub
         self._host = host
         self._attr_unique_id = f"{hub.entry.entry_id}_{host}_ws_connected"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"ap_{host}")},
-            name=f"OpenEPaperLink AP {host}",
-            model=self._hub.ap_model,
-            manufacturer="OpenEPaperLink",
-        )
+        self._attr_device_info = get_ap_device_info(hub, host)
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/open_epaper_link/button.py
+++ b/custom_components/open_epaper_link/button.py
@@ -11,7 +11,7 @@ import json
 import logging
 
 from .tag_types import get_hw_dimensions, get_tag_types_manager
-from .util import send_tag_cmd, reboot_ap
+from .util import get_ap_device_info, reboot_ap, send_tag_cmd
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # Add AP-level buttons
     async_add_entities([
         RebootAPButton(hass, hub),
-        RefreshTagTypesButton(hass),
+        RefreshTagTypesButton(hass, hub),
     ])
 
     # Listen for new tag discoveries
@@ -506,9 +506,7 @@ class RebootAPButton(ButtonEntity):
         Returns:
             dict: Device information dictionary
         """
-        return {
-            "identifiers": {(DOMAIN, "ap")},
-        }
+        return get_ap_device_info(self._hub, self._hub.host)
 
     async def async_press(self) -> None:
         """Handle the button press.
@@ -531,7 +529,7 @@ class RefreshTagTypesButton(ButtonEntity):
     to inform the user of the result.
     """
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, hub) -> None:
         """Initialize the button entity.
 
         Sets up the button with appropriate name, icon, and device association.
@@ -540,6 +538,7 @@ class RefreshTagTypesButton(ButtonEntity):
             hass: Home Assistant instance
         """
         self._hass = hass
+        self._hub = hub
         self._attr_unique_id = "refresh_tag_types"
         # self._attr_name = "Refresh Tag Types"
         self._attr_has_entity_name = True
@@ -557,12 +556,7 @@ class RefreshTagTypesButton(ButtonEntity):
         Returns:
             dict: Device information dictionary
         """
-        return {
-            "identifiers": {(DOMAIN, "ap")},
-            "name": "OpenEPaperLink AP",
-            # "model": self._hub.ap_model,
-            "manufacturer": "OpenEPaperLink",
-        }
+        return get_ap_device_info(self._hub, self._hub.host)
 
     async def async_press(self) -> None:
         """Handle the button press.

--- a/custom_components/open_epaper_link/hub.py
+++ b/custom_components/open_epaper_link/hub.py
@@ -194,6 +194,23 @@ class Hub:
                 await self.async_load_all_tags()
             except Exception as err:
                 _LOGGER.warning("Could not load initial tags from AP: %s", str(err))
+
+            device_registry = dr.async_get(self.hass)
+            device = device_registry.async_get_or_create(
+                config_entry_id=self.entry.entry_id,
+                identifiers={(DOMAIN, "ap")},
+                manufacturer="OpenEPaperLink",
+                model=self.ap_model,
+                name=self.entry.title or "OpenEPaperLink AP",
+            )
+            desired_name = self.entry.title or "OpenEPaperLink AP"
+            if device.name != desired_name:
+                device_registry.async_update_device(device.id, name=desired_name)
+            old_device = device_registry.async_get_device(
+                identifiers={(DOMAIN, f"ap_{self.host}")}
+            )
+            if old_device and old_device.id != device.id:
+                device_registry.async_remove_device(old_device.id)
             return True
 
         except Exception as err:

--- a/custom_components/open_epaper_link/select.py
+++ b/custom_components/open_epaper_link/select.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SIGNAL_EXTERNAL_HUB_DISCOVERED
-from .util import set_ap_config_item
+from .util import get_ap_device_info, set_ap_config_item
 
 import logging
 
@@ -370,19 +370,7 @@ class APConfigSelect(SelectEntity):
         Returns:
             dict: Device information dictionary
         """
-        if self._host == self._hub.host:
-            identifier = "ap"
-            name = "OpenEPaperLink AP"
-        else:
-            identifier = f"ap_{self._host}"
-            name = f"OpenEPaperLink AP {self._host}"
-
-        return {
-            "identifiers": {(DOMAIN, identifier)},
-            "name": name,
-            "model": self._hub.ap_model,
-            "manufacturer": "OpenEPaperLink",
-        }
+        return get_ap_device_info(self._hub, self._host)
 
     @property
     def available(self) -> bool:

--- a/custom_components/open_epaper_link/sensor.py
+++ b/custom_components/open_epaper_link/sensor.py
@@ -32,6 +32,7 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 from .const import DOMAIN, SIGNAL_EXTERNAL_HUB_DISCOVERED
 from .hub import Hub
+from .util import get_ap_device_info
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -608,19 +609,7 @@ class OpenEPaperLinkAPSensor(OpenEPaperLinkBaseSensor):
         # Set device info. Use a stable identifier for the primary hub so
         # sensors and controls share the same device, while secondary hubs
         # retain their host-specific identifiers.
-        if host == self._hub.host:
-            identifier = "ap"
-            name = "OpenEPaperLink AP"
-        else:
-            identifier = f"ap_{host}"
-            name = f"OpenEPaperLink AP {host}"
-
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, identifier)},
-            name=name,
-            model=self._hub.ap_model,
-            manufacturer="OpenEPaperLink",
-        )
+        self._attr_device_info = get_ap_device_info(self._hub, host)
 
     @property
     def available(self) -> bool:

--- a/custom_components/open_epaper_link/switch.py
+++ b/custom_components/open_epaper_link/switch.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SIGNAL_EXTERNAL_HUB_DISCOVERED
-from .util import set_ap_config_item
+from .util import get_ap_device_info, set_ap_config_item
 
 import logging
 
@@ -113,19 +113,7 @@ class APConfigSwitch(SwitchEntity):
             dict: Device information dictionary with identifiers, name,
                   model, and manufacturer
         """
-        if self._host == self._hub.host:
-            identifier = "ap"
-            name = "OpenEPaperLink AP"
-        else:
-            identifier = f"ap_{self._host}"
-            name = f"OpenEPaperLink AP {self._host}"
-
-        return {
-            "identifiers": {(DOMAIN, identifier)},
-            "name": name,
-            "model": self._hub.ap_model,
-            "manufacturer": "OpenEPaperLink",
-        }
+        return get_ap_device_info(self._hub, self._host)
 
     @property
     def available(self) -> bool:

--- a/custom_components/open_epaper_link/text.py
+++ b/custom_components/open_epaper_link/text.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, SIGNAL_EXTERNAL_HUB_DISCOVERED
-from .util import set_ap_config_item
+from .util import get_ap_device_info, set_ap_config_item
 
 import logging
 
@@ -111,19 +111,7 @@ class APConfigText(TextEntity):
             dict: Device information dictionary with identifiers, name,
                   model, and manufacturer
         """
-        if self._host == self._hub.host:
-            identifier = "ap"
-            name = "OpenEPaperLink AP"
-        else:
-            identifier = f"ap_{self._host}"
-            name = f"OpenEPaperLink AP {self._host}"
-
-        return {
-            "identifiers": {(DOMAIN, identifier)},
-            "name": name,
-            "model": self._hub.ap_model,
-            "manufacturer": "OpenEPaperLink",
-        }
+        return get_ap_device_info(self._hub, self._host)
 
     @property
     def available(self) -> bool:

--- a/custom_components/open_epaper_link/util.py
+++ b/custom_components/open_epaper_link/util.py
@@ -5,7 +5,34 @@ import requests
 import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity import DeviceInfo
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_ap_device_info(hub, host: str) -> DeviceInfo:
+    """Return DeviceInfo for an AP, using entry title for the primary hub.
+
+    Args:
+        hub: Hub instance providing context
+        host: IP or hostname of the AP
+
+    Returns:
+        DeviceInfo: Standardized device information for the AP
+    """
+    if host == hub.host:
+        identifier = "ap"
+        name = hub.entry.title or "OpenEPaperLink AP"
+    else:
+        identifier = f"ap_{host}"
+        name = f"OpenEPaperLink AP {host}"
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, identifier)},
+        name=name,
+        model=hub.ap_model,
+        manufacturer="OpenEPaperLink",
+    )
 
 def get_image_folder(hass: HomeAssistant) -> str:
     """Return the folder where images are stored.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub optional Home Assistant dependencies not required for tests
+sys.modules.setdefault("psutil_home_assistant", types.ModuleType("psutil_home_assistant"))
+
+fnv_module = types.ModuleType("fnv_hash_fast")
+fnv_module.fnv1a_32 = lambda data: 0
+sys.modules.setdefault("fnv_hash_fast", fnv_module)

--- a/tests/test_ws_binary_sensor_device_info.py
+++ b/tests/test_ws_binary_sensor_device_info.py
@@ -1,0 +1,32 @@
+import types
+
+from custom_components.open_epaper_link.binary_sensor import (
+    OpenEPaperLinkWSBinarySensor,
+)
+from custom_components.open_epaper_link.const import DOMAIN
+
+
+def test_primary_hub_uses_shared_identifier():
+    hub = types.SimpleNamespace(
+        host="10.0.20.73",
+        entry=types.SimpleNamespace(entry_id="entry", title="Study AP"),
+        ap_model="ESP32",
+        is_online=lambda host: True,
+    )
+    sensor = OpenEPaperLinkWSBinarySensor(hub, hub.host)
+    info = sensor.device_info
+    assert info["identifiers"] == {(DOMAIN, "ap")}
+    assert info["name"] == "Study AP"
+
+
+def test_secondary_hub_uses_host_identifier():
+    hub = types.SimpleNamespace(
+        host="10.0.20.73",
+        entry=types.SimpleNamespace(entry_id="entry", title="Study AP"),
+        ap_model="ESP32",
+        is_online=lambda host: True,
+    )
+    sensor = OpenEPaperLinkWSBinarySensor(hub, "10.0.20.74")
+    info = sensor.device_info
+    assert info["identifiers"] == {(DOMAIN, "ap_10.0.20.74")}
+    assert info["name"] == "OpenEPaperLink AP 10.0.20.74"


### PR DESCRIPTION
## Summary
- centralize AP device info and use config entry title for the primary hub
- register the primary hub device and drop legacy host-based device identifiers
- ensure WebSocket sensor and controls reference the shared device info

## Testing
- `pip install -r requirements_test.txt`
- `pytest` *(fails: text rendering tests due to missing font/coroutine handling)*

------
https://chatgpt.com/codex/tasks/task_e_68b015a11274832bac5dc4909c6cb643