### PR TITLE
Route tag-scoped AP requests to tag's connected AP and add unit tests

### DIFF
--- a/custom_components/open_epaper_link/coordinator.py
+++ b/custom_components/open_epaper_link/coordinator.py
@@ -782,8 +782,56 @@ class Hub:
                 return await func()
             return await self.hass.async_add_executor_job(func)
 
-    async def _ap_request(self, method: str, path: str, *, data=None, timeout=10, action: str) -> requests.Response:
-        url = f"http://{self.host}/{path.lstrip('/')}"
+    def resolve_tag_target_host(
+        self,
+        *,
+        action: str,
+        entity_id: str | None = None,
+        tag_mac: str | None = None,
+    ) -> tuple[str, bool]:
+        """Resolve target AP host for a tag-scoped action.
+
+        Uses the tag's stored connected_ap value when valid, otherwise falls back
+        to the main hub host.
+        """
+        resolved_tag_mac = tag_mac or (
+            entity_id.split(".")[1].upper() if entity_id and "." in entity_id else None
+        )
+        tag_data = self._data.get(resolved_tag_mac, {}) if resolved_tag_mac else {}
+        raw_connected_ap = tag_data.get("connected_ap")
+        connected_ap = normalize_ip(raw_connected_ap)
+
+        fallback_used = connected_ap is None
+        target_host = connected_ap or self.host
+        fallback_reason = None
+        raw_value_for_log = None
+        if fallback_used:
+            fallback_reason = "missing" if raw_connected_ap in (None, "") else "invalid"
+            raw_value_for_log = raw_connected_ap
+        _LOGGER.debug(
+            "Tag HTTP routing action=%s entity_id=%s tag_mac=%s target_host=%s fallback=%s fallback_reason=%s raw_connected_ap=%s",
+            action,
+            entity_id,
+            resolved_tag_mac,
+            target_host,
+            fallback_used,
+            fallback_reason,
+            raw_value_for_log,
+        )
+        return target_host, fallback_used
+
+    async def _ap_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        data=None,
+        timeout=10,
+        action: str,
+        target_host: str | None = None,
+    ) -> requests.Response:
+        request_host = target_host or self.host
+        url = f"http://{request_host}/{path.lstrip('/')}"
         def call():
             return requests.request(method, url, data=data, timeout=timeout)
         try:
@@ -810,12 +858,33 @@ class Hub:
 
     async def set_led_pattern(self, entity_id: str, pattern: str) -> None:
         mac = entity_id.split(".")[1].upper()
-        await self._ap_request("get", f"led_flash?mac={mac}&pattern={pattern}", action=f"update LED for {entity_id}")
+        target_host, _ = self.resolve_tag_target_host(
+            action="setled",
+            entity_id=entity_id,
+            tag_mac=mac,
+        )
+        await self._ap_request(
+            "get",
+            f"led_flash?mac={mac}&pattern={pattern}",
+            action=f"update LED for {entity_id}",
+            target_host=target_host,
+        )
         _LOGGER.info("Updated LED pattern for %s", entity_id)
 
     async def send_tag_cmd(self, entity_id: str, cmd: str) -> bool:
         mac = entity_id.split(".")[1].upper()
-        await self._ap_request("post", "tag_cmd", data={"mac": mac, "cmd": cmd}, action=f"send {cmd} to {entity_id}")
+        target_host, _ = self.resolve_tag_target_host(
+            action=f"tag_cmd:{cmd}",
+            entity_id=entity_id,
+            tag_mac=mac,
+        )
+        await self._ap_request(
+            "post",
+            "tag_cmd",
+            data={"mac": mac, "cmd": cmd},
+            action=f"send {cmd} to {entity_id}",
+            target_host=target_host,
+        )
         _LOGGER.info("Sent %s command to %s", cmd, entity_id)
         return True
 

--- a/custom_components/open_epaper_link/upload.py
+++ b/custom_components/open_epaper_link/upload.py
@@ -234,8 +234,13 @@ async def upload_to_hub(hub, entity_id: str, img: bytes, dither: int, ttl: int,
     Raises:
         HomeAssistantError: If upload fails or times out
     """
-    url = f"http://{hub.host}/imgupload"
     mac = entity_id.split(".")[1].upper()
+    target_host, _ = hub.resolve_tag_target_host(
+        action="imgupload",
+        entity_id=entity_id,
+        tag_mac=mac,
+    )
+    url = f"http://{target_host}/imgupload"
 
     _LOGGER.debug("Preparing upload for %s (MAC: %s)", entity_id, mac)
     _LOGGER.debug("Upload parameters: dither=%d, ttl=%d, preload_type=%d, preload_lut=%d, lut=%d",

--- a/tests/test_tag_routing.py
+++ b/tests/test_tag_routing.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+REPO_ROOT = Path(".").resolve()
+PACKAGE_ROOT = REPO_ROOT / "custom_components" / "open_epaper_link"
+
+if "custom_components" not in sys.modules:
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(REPO_ROOT / "custom_components")]
+    sys.modules["custom_components"] = custom_components_pkg
+
+if "custom_components.open_epaper_link" not in sys.modules:
+    oepl_pkg = types.ModuleType("custom_components.open_epaper_link")
+    oepl_pkg.__path__ = [str(PACKAGE_ROOT)]
+    sys.modules["custom_components.open_epaper_link"] = oepl_pkg
+
+spec = importlib.util.spec_from_file_location(
+    "custom_components.open_epaper_link.coordinator",
+    PACKAGE_ROOT / "coordinator.py",
+)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules["custom_components.open_epaper_link.coordinator"] = module
+spec.loader.exec_module(module)
+Hub = module.Hub
+
+
+def _build_hub(host: str = "10.0.20.73") -> Hub:
+    """Create a minimal Hub object for unit testing helper behavior."""
+    hub = Hub.__new__(Hub)
+    hub.host = host
+    hub._data = {}
+    return hub
+
+
+def test_resolve_tag_target_host_uses_valid_connected_ap() -> None:
+    hub = _build_hub()
+    hub._data["AA11BB22CC33"] = {"connected_ap": "10.0.20.74"}
+
+    target_host, fallback_used = hub.resolve_tag_target_host(
+        action="tag_cmd:refresh",
+        entity_id="open_epaper_link.aa11bb22cc33",
+    )
+
+    assert target_host == "10.0.20.74"
+    assert fallback_used is False
+
+
+def test_resolve_tag_target_host_falls_back_when_missing_connected_ap() -> None:
+    hub = _build_hub(host="10.0.20.73")
+    hub._data["AA11BB22CC33"] = {}
+
+    target_host, fallback_used = hub.resolve_tag_target_host(
+        action="setled",
+        entity_id="open_epaper_link.aa11bb22cc33",
+    )
+
+    assert target_host == "10.0.20.73"
+    assert fallback_used is True
+
+
+def test_resolve_tag_target_host_falls_back_when_invalid_connected_ap() -> None:
+    hub = _build_hub(host="10.0.20.73")
+    hub._data["AA11BB22CC33"] = {"connected_ap": "invalid-hostname"}
+
+    target_host, fallback_used = hub.resolve_tag_target_host(
+        action="imgupload",
+        entity_id="open_epaper_link.aa11bb22cc33",
+    )
+
+    assert target_host == "10.0.20.73"
+    assert fallback_used is True
+
+
+def test_send_tag_cmd_passes_resolved_target_host() -> None:
+    hub = _build_hub(host="10.0.20.73")
+    hub._data["AA11BB22CC33"] = {"connected_ap": "10.0.20.90"}
+    hub._ap_request = AsyncMock(return_value=SimpleNamespace(status_code=200))
+
+    asyncio.run(hub.send_tag_cmd("open_epaper_link.aa11bb22cc33", "refresh"))
+
+    hub._ap_request.assert_awaited_once()
+    _, kwargs = hub._ap_request.await_args
+    assert kwargs["target_host"] == "10.0.20.90"
+    assert kwargs["data"] == {"mac": "AA11BB22CC33", "cmd": "refresh"}


### PR DESCRIPTION
### Motivation

The previous multi-hub groundwork added per-tag `connected_ap` tracking, but AP-backed tag actions were still always sent to the main hub. This PR updates tag-scoped HTTP operations so they are routed directly to the AP the tag is currently connected to.

### What this PR adds

- Direct AP routing for tag-scoped HTTP operations based on each tag’s stored `connected_ap`
- Unified debug logging for routing decisions
- Unit tests covering routing resolution and command dispatch

### Routed operations

This PR now sends the following AP-backed tag operations directly to the tag’s resolved `connected_ap`:

- image uploads via `/imgupload`
- LED pattern updates via `/led_flash`
- tag commands via `/tag_cmd`, including:
  - clear
  - refresh
  - reboot
  - scan
  - deepsleep

This applies both to service-driven flows and to tag button entities that call `send_tag_cmd(...)` directly.

### Routing behavior

For AP-backed tag operations:

- If `connected_ap` contains a valid IP, the request is sent directly to that AP
- If `connected_ap` is missing or invalid, the integration falls back to the main hub host
- Each routing decision is logged once with:
  - action
  - entity_id
  - tag_mac
  - resolved target host
  - whether fallback was used
  - fallback reason when applicable

### What does not change

This PR does **not** change AP-global behavior.

The following still target the main hub:

- AP reboot via `/reboot`
- AP config updates via `/save_apcfg`
- AP info/config fetches such as `/sysinfo`, `/get_db`, and `/get_ap_config`
- websocket connection lifecycle

BLE behavior is also unchanged.

### Testing

Added unit tests for:

- valid `connected_ap` routing to the remote AP
- fallback to the main hub when `connected_ap` is missing
- fallback to the main hub when `connected_ap` is invalid
- `send_tag_cmd(...)` forwarding the resolved `target_host` into `_ap_request(...)`

### Why this matters

This is the first step where multi-hub awareness becomes operational instead of only diagnostic. Tags can now receive updates and commands through the AP they are actually connected to, which is a necessary building block for proper multi-hub support.