### PR TITLE
Include target AP IP in upload and tag command logs

### DIFF
--- a/custom_components/open_epaper_link/coordinator.py
+++ b/custom_components/open_epaper_link/coordinator.py
@@ -869,7 +869,7 @@ class Hub:
             action=f"update LED for {entity_id}",
             target_host=target_host,
         )
-        _LOGGER.info("Updated LED pattern for %s", entity_id)
+        _LOGGER.info("Updated LED pattern for %s via AP %s", entity_id, target_host)
 
     async def send_tag_cmd(self, entity_id: str, cmd: str) -> bool:
         mac = entity_id.split(".")[1].upper()
@@ -885,7 +885,7 @@ class Hub:
             action=f"send {cmd} to {entity_id}",
             target_host=target_host,
         )
-        _LOGGER.info("Sent %s command to %s", cmd, entity_id)
+        _LOGGER.info("Sent %s command to %s via AP %s", cmd, entity_id, target_host)
         return True
 
     async def reboot_ap(self) -> bool:

--- a/custom_components/open_epaper_link/upload.py
+++ b/custom_components/open_epaper_link/upload.py
@@ -242,9 +242,22 @@ async def upload_to_hub(hub, entity_id: str, img: bytes, dither: int, ttl: int,
     )
     url = f"http://{target_host}/imgupload"
 
-    _LOGGER.debug("Preparing upload for %s (MAC: %s)", entity_id, mac)
-    _LOGGER.debug("Upload parameters: dither=%d, ttl=%d, preload_type=%d, preload_lut=%d, lut=%d",
-                  dither, ttl, preload_type, preload_lut, lut)
+    _LOGGER.debug(
+        "Preparing upload for %s (MAC: %s) via AP %s",
+        entity_id,
+        mac,
+        target_host,
+    )
+    _LOGGER.debug(
+        "Upload parameters for %s via AP %s: dither=%d, ttl=%d, preload_type=%d, preload_lut=%d, lut=%d",
+        entity_id,
+        target_host,
+        dither,
+        ttl,
+        preload_type,
+        preload_lut,
+        lut,
+    )
 
     # Convert TTL fom seconds to minutes for the AP
     ttl_minutes = max(1, ttl // 60)
@@ -292,8 +305,12 @@ async def upload_to_hub(hub, entity_id: str, img: bytes, dither: int, ttl: int,
         except asyncio.TimeoutError:
             if attempt < MAX_RETRIES:
                 _LOGGER.warning(
-                    "Timeout uploading %s (attempt %d/%d), retrying in %ds…",
-                    entity_id, attempt, MAX_RETRIES, backoff_delay
+                    "Timeout uploading %s via AP %s (attempt %d/%d), retrying in %ds…",
+                    entity_id,
+                    target_host,
+                    attempt,
+                    MAX_RETRIES,
+                    backoff_delay,
                 )
                 await asyncio.sleep(backoff_delay)
                 backoff_delay *= 2


### PR DESCRIPTION
### Motivation
- Improve observability by including the resolved AP IP (target host) in logs for image uploads and AP-directed tag commands so failures and timeouts can be traced to the destination device.

### Description
- In `upload_to_hub` (in `custom_components/open_epaper_link/upload.py`) add the resolved `target_host` to the upload start debug log and to the upload-parameters debug log, and include `target_host` in the timeout retry warning message.
- In `Hub.set_led_pattern` and `Hub.send_tag_cmd` (in `custom_components/open_epaper_link/coordinator.py`) include the resolved `target_host` in the success/info logs for clearer AP routing context.
- Minor formatting updates to the log statements to include `entity_id`, `mac`, and `target_host` where applicable.

### Testing
- Ran `python -m compileall custom_components/open_epaper_link/upload.py custom_components/open_epaper_link/coordinator.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1387007d4832b8e1e1d61bc53e24a)