### PR TITLE
Include AP IP in upload success logs

### DIFF
--- a/custom_components/open_epaper_link/upload.py
+++ b/custom_components/open_epaper_link/upload.py
@@ -186,11 +186,15 @@ class UploadQueueHandler:
 
     async def _execute_upload(self, upload_func, args, kwargs, entity_id):
         """Execute a single upload task in the background."""
+        ap_ip = self._resolve_ap_ip_for_upload(args, entity_id)
         try:
             # TODO don't we need the incrementation logic here?
             _LOGGER.debug("Starting upload for %s", entity_id)
             await upload_func(*args, **kwargs)
-            _LOGGER.info("Successfully completed upload for %s", entity_id)
+            if ap_ip:
+                _LOGGER.info("Successfully completed upload for %s via AP %s", entity_id, ap_ip)
+            else:
+                _LOGGER.info("Successfully completed upload for %s", entity_id)
 
         except (ServiceValidationError, HomeAssistantError) as err:
             # Log and re-raise - let service handler collect errors
@@ -210,6 +214,28 @@ class UploadQueueHandler:
             # Mark task as done
             self._queue.task_done()
             _LOGGER.debug("Upload task for %s finished. %s", entity_id, self)
+
+    @staticmethod
+    def _resolve_ap_ip_for_upload(args, entity_id: str) -> str | None:
+        """Resolve AP IP for hub uploads if available."""
+        if not args or "." not in entity_id:
+            return None
+
+        hub = args[0]
+        if not hasattr(hub, "resolve_tag_target_host"):
+            return None
+
+        try:
+            mac = entity_id.split(".")[1].upper()
+            target_host, _ = hub.resolve_tag_target_host(
+                action="imgupload",
+                entity_id=entity_id,
+                tag_mac=mac,
+            )
+            return target_host
+        except Exception as err:  # Best effort only for logging context
+            _LOGGER.debug("Could not resolve AP host for %s: %s", entity_id, err)
+            return None
 
 
 async def upload_to_hub(hub, entity_id: str, img: bytes, dither: int, ttl: int,


### PR DESCRIPTION
### Motivation
- Improve observability of hub-based image uploads by recording the AP IP address used for the upload in successful log entries.
- Provide this information in a best-effort, non-intrusive way without changing behavior for non-AP uploads (e.g., BLE).

### Description
- Added a best-effort resolver method `UploadQueueHandler._resolve_ap_ip_for_upload` that extracts the hub from queued args and calls `resolve_tag_target_host(...)` to determine the AP IP if available.
- Updated `_execute_upload` to call the resolver and log success as `Successfully completed upload for <entity_id> via AP <ip>` when an AP IP could be resolved, and fall back to the existing message otherwise.
- The resolver is defensive and returns `None` on any failures so it only augments logs and does not affect upload flow.
- Change applied to `custom_components/open_epaper_link/upload.py`.

### Testing
- Compiled the module with `python -m compileall custom_components/open_epaper_link/upload.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13ab37b10832ba23a84c0978e5e9b)