### PR TITLE
Remove configuration_url for discovered APs and debounce discovered-hub storage saves

### DIFF
--- a/custom_components/open_epaper_link/coordinator.py
+++ b/custom_components/open_epaper_link/coordinator.py
@@ -117,6 +117,7 @@ class Hub:
         self._ap_cmd_sem = asyncio.Semaphore(1)
         self._ap_cmd_cooldown = 0.5
         self._discovered_hubs: dict[str, dict[str, Any]] = {}
+        self._scheduled_storage_save: asyncio.TimerHandle | None = None
 
     def _update_debounce_interval(self) -> None:
         """Update event debounce intervals from integration options.
@@ -302,7 +303,27 @@ class Hub:
         self.online = False
         async_dispatcher_send(self.hass, f"{DOMAIN}_connection_status", False)
 
+        if self._scheduled_storage_save:
+            self._scheduled_storage_save.cancel()
+            self._scheduled_storage_save = None
+
         _LOGGER.debug("OpenEPaperLink hub shutdown complete")
+
+    def _schedule_storage_save(self, delay: float = SAVE_DELAY) -> None:
+        """Schedule a debounced storage write."""
+        if self._scheduled_storage_save:
+            self._scheduled_storage_save.cancel()
+
+        self._scheduled_storage_save = self.hass.loop.call_later(
+            delay,
+            self._flush_scheduled_storage_save,
+        )
+
+    @callback
+    def _flush_scheduled_storage_save(self) -> None:
+        """Flush a scheduled storage write."""
+        self._scheduled_storage_save = None
+        self.hass.async_create_task(self._store.async_save(self._build_storage_payload()))
 
     async def _websocket_handler(self) -> None:
         """Handle WebSocket connection lifecycle and process messages.
@@ -1175,7 +1196,7 @@ class Hub:
                 "discovered_hubs": self._discovered_hubs,
             })
 
-    async def _handle_ap_config_message(self,dict) -> None:
+    async def _handle_ap_config_message(self, message: dict[str, Any]) -> None:
         """Handle AP configuration updates.
 
         Fetches the current AP configuration via HTTP and updates the
@@ -1188,6 +1209,7 @@ class Hub:
         Args:
             message: The configuration message from the AP
         """
+        del message
         try:
             if self._shutdown.is_set():
                 return
@@ -1554,7 +1576,7 @@ class Hub:
             _LOGGER.info("Discovered remote AP hub %s via %s (evidence: %s)", hub_id, source, evidence_path)
             async_dispatcher_send(self.hass, SIGNAL_REMOTE_AP_DISCOVERED, hub_id)
             async_dispatcher_send(self.hass, SIGNAL_AP_UPDATE)
-            self.hass.async_create_task(self._store.async_save(self._build_storage_payload()))
+            self._schedule_storage_save()
             return
 
         updated = False
@@ -1572,7 +1594,7 @@ class Hub:
         if updated:
             _LOGGER.info("Updated remote AP hub metadata for %s via %s", hub_id, source)
             async_dispatcher_send(self.hass, SIGNAL_AP_UPDATE)
-            self.hass.async_create_task(self._store.async_save(self._build_storage_payload()))
+            self._schedule_storage_save()
 
     @staticmethod
     def _format_ap_model(ap_env: str) -> str:

--- a/custom_components/open_epaper_link/entity.py
+++ b/custom_components/open_epaper_link/entity.py
@@ -97,7 +97,6 @@ class OpenEPaperLinkDiscoveredAPEntity(Entity):
             model=model,
             manufacturer="OpenEPaperLink",
             via_device=(DOMAIN, "ap"),
-            configuration_url=f"http://{self._hub.host}",
         )
 
     @property

--- a/tests/test_discovered_hub_metadata.py
+++ b/tests/test_discovered_hub_metadata.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest.mock import Mock
+
+REPO_ROOT = Path(".").resolve()
+PACKAGE_ROOT = REPO_ROOT / "custom_components" / "open_epaper_link"
+
+if "custom_components" not in sys.modules:
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(REPO_ROOT / "custom_components")]
+    sys.modules["custom_components"] = custom_components_pkg
+
+if "custom_components.open_epaper_link" not in sys.modules:
+    oepl_pkg = types.ModuleType("custom_components.open_epaper_link")
+    oepl_pkg.__path__ = [str(PACKAGE_ROOT)]
+    sys.modules["custom_components.open_epaper_link"] = oepl_pkg
+
+if "homeassistant.components" not in sys.modules:
+    ha_components = types.ModuleType("homeassistant.components")
+    sys.modules["homeassistant.components"] = ha_components
+
+if "homeassistant.components.bluetooth" not in sys.modules:
+    ha_bluetooth = types.ModuleType("homeassistant.components.bluetooth")
+    ha_bluetooth.async_address_present = lambda *args, **kwargs: True
+    sys.modules["homeassistant.components.bluetooth"] = ha_bluetooth
+
+if "custom_components.open_epaper_link.ble" not in sys.modules:
+    ble_module = types.ModuleType("custom_components.open_epaper_link.ble")
+
+    class _BLEDeviceMetadata:
+        pass
+
+    ble_module.BLEDeviceMetadata = _BLEDeviceMetadata
+    sys.modules["custom_components.open_epaper_link.ble"] = ble_module
+
+entity_spec = importlib.util.spec_from_file_location(
+    "custom_components.open_epaper_link.entity",
+    PACKAGE_ROOT / "entity.py",
+)
+entity_module = importlib.util.module_from_spec(entity_spec)
+assert entity_spec and entity_spec.loader
+sys.modules["custom_components.open_epaper_link.entity"] = entity_module
+entity_spec.loader.exec_module(entity_module)
+OpenEPaperLinkDiscoveredAPEntity = entity_module.OpenEPaperLinkDiscoveredAPEntity
+
+coordinator_spec = importlib.util.spec_from_file_location(
+    "custom_components.open_epaper_link.coordinator",
+    PACKAGE_ROOT / "coordinator.py",
+)
+coordinator_module = importlib.util.module_from_spec(coordinator_spec)
+assert coordinator_spec and coordinator_spec.loader
+sys.modules["custom_components.open_epaper_link.coordinator"] = coordinator_module
+coordinator_spec.loader.exec_module(coordinator_module)
+Hub = coordinator_module.Hub
+coordinator_module.async_dispatcher_send = Mock()
+
+
+def test_discovered_ap_device_info_omits_configuration_url() -> None:
+    hub = Mock()
+    hub.get_discovered_hub.return_value = {
+        "metadata": {"model": "Mini AP"},
+        "ip": "10.0.20.74",
+    }
+    entity = OpenEPaperLinkDiscoveredAPEntity(hub, "10.0.20.74")
+
+    device_info = entity.device_info
+
+    assert "configuration_url" not in device_info
+    assert device_info["via_device"] == ("open_epaper_link", "ap")
+
+
+def test_upsert_discovered_hub_schedules_storage_save_for_new_hub() -> None:
+    hub = Hub.__new__(Hub)
+    hub._discovered_hubs = {}
+    hub._schedule_storage_save = Mock()
+    hub.hass = Mock()
+
+    hub._upsert_discovered_hub(
+        {
+            "hub_id": "10.0.20.74",
+            "ip": "10.0.20.74",
+            "metadata": {"source": "tag_apip"},
+            "evidence_path": "tag[AA11].apip",
+        },
+        source="tag.apip",
+    )
+
+    hub._schedule_storage_save.assert_called_once()
+
+
+def test_upsert_discovered_hub_schedules_storage_save_for_metadata_update() -> None:
+    hub = Hub.__new__(Hub)
+    hub._discovered_hubs = {
+        "10.0.20.74": {
+            "hub_id": "10.0.20.74",
+            "ip": "10.0.20.74",
+            "last_seen": "2026-04-05T00:00:00+00:00",
+            "discovery_sources": ["tag.apip"],
+            "metadata": {"source": "tag_apip"},
+            "evidence_path": "tag[AA11].apip",
+        }
+    }
+    hub._schedule_storage_save = Mock()
+    hub.hass = Mock()
+
+    hub._upsert_discovered_hub(
+        {
+            "hub_id": "10.0.20.74",
+            "ip": "10.0.20.74",
+            "metadata": {"source": "http_sysinfo"},
+            "evidence_path": "sys.info",
+        },
+        source="http_sysinfo",
+    )
+
+    hub._schedule_storage_save.assert_called_once()


### PR DESCRIPTION
### Motivation
- Discovered remote AP entries are diagnostic only and must not advertise a Home Assistant `configuration_url` for a hub that is not a first-class configured endpoint. 
- Reduce aggressive storage write churn from frequent discovered-hub updates by introducing a debounced/scheduled save path. 
- Clean up a handler signature to use a proper parameter name and type hint while leaving routing and websocket behavior unchanged.

### Description
- Removed the `configuration_url` from discovered AP device metadata in `OpenEPaperLinkDiscoveredAPEntity.device_info` so discovered AP entities no longer advertise a misleading HA configuration URL (`custom_components/open_epaper_link/entity.py`).
- Added a debounced storage-save mechanism to `Hub`: `self._scheduled_storage_save`, `_schedule_storage_save(delay: float = SAVE_DELAY)`, and `_flush_scheduled_storage_save()` to coalesce writes and perform the actual `async_save` after a delay, and added cancellation of any pending timer during shutdown (`custom_components/open_epaper_link/coordinator.py`).
- Switched `_upsert_discovered_hub(...)` to call `_schedule_storage_save()` instead of creating immediate `async_save(...)` tasks for both new discoveries and metadata updates (`custom_components/open_epaper_link/coordinator.py`).
- Renamed and type-hinted the AP config handler from `_handle_ap_config_message(self, dict)` to `_handle_ap_config_message(self, message: dict[str, Any])` and added a `del message` placeholder to avoid unused-parameter warnings (`custom_components/open_epaper_link/coordinator.py`).
- Added focused unit tests that verify discovered AP device info no longer includes `configuration_url` and that `_upsert_discovered_hub` schedules a storage save on new hub discovery and on metadata updates (`tests/test_discovered_hub_metadata.py`).

Files changed:
- `custom_components/open_epaper_link/entity.py`
- `custom_components/open_epaper_link/coordinator.py`
- `tests/test_discovered_hub_metadata.py`

### Testing
- Ran `pytest -q tests/test_remote_ap_discovery.py tests/test_tag_routing.py tests/test_discovered_hub_metadata.py` and all tests passed (`11 passed`).
- The existing connected-AP routing tests remained unchanged and continue to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1ee04cb34832ba323574b9dc32a4b)